### PR TITLE
Change order of operations for timecode from date

### DIFF
--- a/smpte-timecode.js
+++ b/smpte-timecode.js
@@ -50,7 +50,7 @@
         }
         else if (typeof timeCode == 'object' && timeCode instanceof Date) {
             var midnight = new Date( timeCode.getFullYear(), timeCode.getMonth(), timeCode.getDate(),0,0,0 );
-    		this.frameCount = Math.floor(((timeCode-midnight)*this.frameRate))/1000;
+    		this.frameCount = Math.floor(((timeCode-midnight)*this.frameRate)/1000);
         }
         else if (typeof timeCode == 'undefined') {
             this.frameCount = 0;

--- a/smpte-timecode.js
+++ b/smpte-timecode.js
@@ -50,7 +50,7 @@
         }
         else if (typeof timeCode == 'object' && timeCode instanceof Date) {
             var midnight = new Date( timeCode.getFullYear(), timeCode.getMonth(), timeCode.getDate(),0,0,0 );
-    		this.frameCount = Math.floor(((timeCode-midnight)/1000)*this.frameRate);
+    		this.frameCount = Math.floor(((timeCode-midnight)*this.frameRate))/1000;
         }
         else if (typeof timeCode == 'undefined') {
             this.frameCount = 0;

--- a/test/smpte-timecode-test.js
+++ b/test/smpte-timecode-test.js
@@ -157,6 +157,10 @@ describe('Date() operations', function(){
         var t = new Timecode( new Date(0,0,0,1,2,13,200), 29.97, true );
         expect( t.frameCount ).to.be(111884);
         expect( t.toString()).to.be('01:02:13;06');
+        
+        var t2 = new Timecode( new Date(0,0,0,10,40,15,520), 25, false );
+        expect( t.frameCount ).to.be(960388);
+        expect( t.toString()).to.be('10:40:15:13');
     });
     it ('Timecode to Date()', function(){
         var d = Timecode('01:23:45;10').toDate();

--- a/test/smpte-timecode-test.js
+++ b/test/smpte-timecode-test.js
@@ -159,8 +159,8 @@ describe('Date() operations', function(){
         expect( t.toString()).to.be('01:02:13;06');
         
         var t2 = new Timecode( new Date(0,0,0,10,40,15,520), 25, false );
-        expect( t.frameCount ).to.be(960388);
-        expect( t.toString()).to.be('10:40:15:13');
+        expect( t2.frameCount ).to.be(960388);
+        expect( t2.toString()).to.be('10:40:15:13');
     });
     it ('Timecode to Date()', function(){
         var d = Timecode('01:23:45;10').toDate();


### PR DESCRIPTION
Change the order of operations when creating timecode from date to reduce loss of precision due to dividing before multiplying. 