### PR TITLE
Fix add() logic to use original frame rate

### DIFF
--- a/smpte-timecode.js
+++ b/smpte-timecode.js
@@ -189,7 +189,7 @@
             this.frameCount = newFrameCount;
         }
         else {
-            if (!(t instanceof Timecode)) t = new Timecode(t);
+            if (!(t instanceof Timecode)) t = new Timecode(t, this.frameRate, this.dropFrame);
             return this.add(t.frameCount,negative,rollOverMaxHours);
         }
         this.frameCount = this.frameCount % (Math.round(this.frameRate*86400)); // wraparound 24h

--- a/test/smpte-timecode-test.js
+++ b/test/smpte-timecode-test.js
@@ -157,6 +157,9 @@ describe('Timecode arithmetic', function(){
        expect(function() { new Timecode().subtract(new Timecode('22:30:00;00'), 1); }).to.throwError();
        expect(new Timecode('01:00:00;00').subtract(new Timecode('23:30:00;00'), 2).toString()).to.be('01:30:00;00');
     });
+    it('Ensures source frame rate is kept when adding two Timecode objects', function() {
+        expect(new Timecode('00:00:00:00', 25, false).add('00:01:00:00').frameCount).to.be(1500);
+    });
 });
 
 describe('Date() operations', function(){


### PR DESCRIPTION
Right now, if you run

```
let t = Timecode('00:00:00:00', 25, false);
t.add('00:00:10:00');
console.log(t.frameCount);
```

Instead of adding 250 frames, this code adds 300. If you pass the add function a timecode string, it calls the basic constructor that assumes the frame rate and drop frame attributes. This PR changes the implementation to assume that any added timecode string has the same frame rate + drop frame attributes as the original timecode.