### PR TITLE
Allow passing in 30000/1001 or 60000/1001 frame rates

### DIFF
--- a/test/smpte-timecode-test.js
+++ b/test/smpte-timecode-test.js
@@ -63,7 +63,9 @@ describe('Constructor tests', function(){
         expect(Timecode(1).dropFrame).to.be(true);
         expect(Timecode(1).frameRate).to.be(29.97);
         expect(Timecode(1,29.97).dropFrame).to.be(true);
+        expect(Timecode(1,30000/1001).dropFrame).to.be(true);
         expect(Timecode(1,59.94).dropFrame).to.be(true);
+        expect(Timecode(1,60000/1001).dropFrame).to.be(true);
         expect(Timecode(1,25).dropFrame).to.be(false);
     });
 


### PR DESCRIPTION
Instead of checking for exactly 29.97 or 59.94, check that the frame
rate is close enough to those values. Also centralize the source of
truth for the number of frames to drop in DF mode.