### PR TITLE
Stringify timecodes when converted to JSON

### DIFF
--- a/smpte-timecode.js
+++ b/smpte-timecode.js
@@ -133,7 +133,7 @@
      * @param {String} format output format
      * @returns {string} timecode
      */
-    Timecode.prototype.toString = Timecode.prototype.toJSON = function TimeCodeToString(format) {
+    Timecode.prototype.toString = function TimeCodeToString(format) {
         var frames = this.frames;
         var field = '';
         if (typeof format === 'string') {
@@ -161,6 +161,14 @@
             field
         );
     };
+    
+    /**
+     * Serializes a Timecode when stringifying a JSON object
+     * @returns {string} timecode
+     */
+    Timecode.prototype.toJSON = function SerializeTimeCode() {
+        return this.toString()
+    }
 
     /**
      * @returns {Number} the frame count when Timecode() object is used as a number

--- a/smpte-timecode.js
+++ b/smpte-timecode.js
@@ -167,8 +167,8 @@
      * @returns {string} timecode
      */
     Timecode.prototype.toJSON = function SerializeTimeCode() {
-        return this.toString()
-    }
+        return this.toString();
+    };
 
     /**
      * @returns {Number} the frame count when Timecode() object is used as a number

--- a/smpte-timecode.js
+++ b/smpte-timecode.js
@@ -133,7 +133,7 @@
      * @param {String} format output format
      * @returns {string} timecode
      */
-    Timecode.prototype.toString = function TimeCodeToString(format) {
+    Timecode.prototype.toString = Timecode.prototype.toJSON = function TimeCodeToString(format) {
         var frames = this.frames;
         var field = '';
         if (typeof format === 'string') {


### PR DESCRIPTION
This patch sets the [`toJSON()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON_behavior) function such that when stringifying an object, the timecode is output in its string form, rather than its object form.

Before:
```
> JSON.stringify({ timecode: Timecode(34) })
'{"timecode":{"frameRate":29.97,"dropFrame":true,"frameCount":34,"frames":4,"seconds":1,"minutes":0,"hours":0}}'
```

After:
```
> JSON.stringify({ timecode: Timecode(34) })
'{"timecode":"00:00:01;04"}'
```